### PR TITLE
fix: unicorn/filename-case で __tests__・__mocks__ 等のダブルアンダースコアディレクトリを対象外にする

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -84,6 +84,13 @@ export default tseslint.config(
     },
   },
   {
+    // __tests__ や __mocks__ など、Jest 等の規約に基づく
+    // ダブルアンダースコアディレクトリ名を unicorn/filename-case の対象外とする
+    rules: {
+      "unicorn/filename-case": ["error", { ignore: [/^__[\w-]+__$/] }],
+    },
+  },
+  {
     ignores: ["dist", "output", "node_modules", "data", "logs", "coverage"],
   },
   eslintPrettier

--- a/test.mjs
+++ b/test.mjs
@@ -179,13 +179,46 @@ async function main() {
       shouldError: false,
       rules: ["unicorn/catch-error-name"],
     },
+    {
+      name: "filename-case: __tests__ ディレクトリはケースチェック対象外（OK）",
+      code: "export const a = 1;",
+      shouldError: false,
+      rules: ["unicorn/filename-case"],
+      dir: "__tests__",
+    },
+    {
+      name: "filename-case: __mocks__ ディレクトリはケースチェック対象外（OK）",
+      code: "export const a = 1;",
+      shouldError: false,
+      rules: ["unicorn/filename-case"],
+      dir: "__mocks__",
+    },
+    {
+      name: "filename-case: kebab-case でないディレクトリ名はエラー",
+      code: "export const a = 1;",
+      shouldError: true,
+      rules: ["unicorn/filename-case"],
+      dir: "notKebabCaseDir",
+    },
   ];
 
   // テスト用一時ファイルをsrc/配下に作成することで、flat configのfiles: ["**/*.ts"]に確実にマッチさせる
-  const tmpDir = path.join(process.cwd(), "src", "__tmp__cli");
-  if (!fs.existsSync(path.join(process.cwd(), "src")))
-    fs.mkdirSync(path.join(process.cwd(), "src"));
+  const srcDir = path.join(process.cwd(), "src");
+  const tmpDir = path.join(srcDir, "__tmp__cli");
+  if (!fs.existsSync(srcDir)) fs.mkdirSync(srcDir);
   if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir);
+
+  // テストケースごとに dir（src 配下の任意のディレクトリ名）が指定されていれば、
+  // unicorn/filename-case のディレクトリ名チェックを検証するために作成する
+  const extraDirs = new Set(
+    testCases
+      .map((testCase) => testCase.dir)
+      .filter((dir) => dir && dir !== "__tmp__cli")
+  );
+  for (const dir of extraDirs) {
+    const dirPath = path.join(srcDir, dir);
+    if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
+  }
 
   // テスト用tsconfig.jsonを作成
   const tsconfigPath = path.join(process.cwd(), "tsconfig.json");
@@ -215,9 +248,10 @@ async function main() {
   // 並列実行用のPromise配列
   const promises = testCases.map((testCase, i) => {
     return new Promise((resolve) => {
-      const { name, code, shouldError, rules } = testCase;
+      const { name, code, shouldError, rules, dir } = testCase;
       const kebabName = `test-${i}.ts`;
-      const tmpFilePath = path.join(tmpDir, kebabName);
+      const targetDir = dir ? path.join(srcDir, dir) : tmpDir;
+      const tmpFilePath = path.join(targetDir, kebabName);
       fs.writeFileSync(tmpFilePath, code);
       exec(
         `npx eslint --no-cache --ext .ts ${tmpFilePath}`,
@@ -288,6 +322,9 @@ async function main() {
 
   fs.unlinkSync(flatConfigPath);
   fs.rmSync(tmpDir, { recursive: true });
+  for (const dir of extraDirs) {
+    fs.rmSync(path.join(srcDir, dir), { recursive: true });
+  }
   fs.unlinkSync(tsconfigPath);
   console.log("\n--- サマリ ---");
   console.log(`成功: ${pass} / 失敗: ${fail} / 合計: ${testCases.length}`);


### PR DESCRIPTION
## 概要

eslint-plugin-unicorn v65 系へのアップデートに伴い、`unicorn/filename-case` ルールが `__tests__` や `__mocks__` などの Jest 規約に基づくダブルアンダースコアディレクトリ名を kebab-case 違反として検出するようになりました。

これらのディレクトリ名は `__tests__` → 末尾の `__` が kebab-case 変換で取り除かれるため `tests__` !== `tests` となり、常に違反として検出されてしまいます。Jest などのツールチェーンの規約上、これらのディレクトリ名を変更することは現実的ではありません。

## 修正内容

`unicorn/filename-case` に `ignore: [/^__[\w-]+__$/]` を追加し、`__tests__` / `__mocks__` などのダブルアンダースコアディレクトリ名をチェック対象外にしました。

```diff
   {
     // catch ブロックのエラー変数名は error に統一する。
     // err も常に許容する（error_ は要求しない）。
     rules: {
       "unicorn/catch-error-name": ["error", { name: "error", ignore: [/^err$/] }],
     },
   },
+  {
+    // __tests__ や __mocks__ など、Jest 等の規約に基づく
+    // ダブルアンダースコアディレクトリ名を unicorn/filename-case の対象外とする
+    rules: {
+      "unicorn/filename-case": ["error", { ignore: [/^__[\w-]+__$/] }],
+    },
+  },
```

`test.mjs` にも以下のテストケースを追加しています:
- `__tests__` / `__mocks__` ディレクトリ配下のファイルが `unicorn/filename-case` でエラーにならないこと
- kebab-case でないディレクトリ名（`notKebabCaseDir`）は引き続きエラーになること（既存挙動の確認）

`pnpm test` で全 32 件のテストが成功することを確認済みです。

## 背景

このリポジトリの `@book000/eslint-config` を利用している複数リポジトリで、`v1.14.59` への更新 PR の CI が `unicorn/filename-case` の新規違反により失敗しています。本修正により、これらのリポジトリでの誤検出を解消します。