### PR TITLE
fix: テスト用ディレクトリのクリーンアップで既存ディレクトリを誤って削除しないようにする

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -215,9 +215,15 @@ async function main() {
       .map((testCase) => testCase.dir)
       .filter((dir) => dir && dir !== "__tmp__cli")
   );
+  // クリーンアップ時に削除してよいのは、このテストで新規に作成したディレクトリのみとする
+  // （既存の src/__tests__ 等を誤って削除しないようにするため）
+  const createdExtraDirs = new Set();
   for (const dir of extraDirs) {
     const dirPath = path.join(srcDir, dir);
-    if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+      createdExtraDirs.add(dir);
+    }
   }
 
   // テスト用tsconfig.jsonを作成
@@ -322,7 +328,7 @@ async function main() {
 
   fs.unlinkSync(flatConfigPath);
   fs.rmSync(tmpDir, { recursive: true });
-  for (const dir of extraDirs) {
+  for (const dir of createdExtraDirs) {
     fs.rmSync(path.join(srcDir, dir), { recursive: true });
   }
   fs.unlinkSync(tsconfigPath);


### PR DESCRIPTION
## 概要

#534 の Copilot レビューで指摘された問題を修正します。

`test.mjs` の `filename-case` テストでは、`src/<dir>` (例: `src/__tests__`, `src/__mocks__`) を
テスト用に作成していましたが、クリーンアップ時には作成有無を確認せず `fs.rmSync(..., { recursive: true })`
で削除していました。リポジトリに既存の `src/__tests__` / `src/__mocks__` 等がある場合、
テスト実行によって実ファイルまで削除してしまう可能性がありました。

## 変更内容

- テスト用ディレクトリを新規作成した場合のみ `createdExtraDirs` に記録するようにし、
  クリーンアップでは `createdExtraDirs` に含まれるディレクトリのみを削除するように変更

## 動作確認

`pnpm test` で 32/32 成功することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)