### PR TITLE
fix: unicorn/filename-case でディレクトリ名チェックを無効化し src 等の慣習的なディレクトリ名を許容する

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -84,10 +84,18 @@ export default tseslint.config(
     },
   },
   {
-    // __tests__ や __mocks__ など、Jest 等の規約に基づく
-    // ダブルアンダースコアディレクトリ名を unicorn/filename-case の対象外とする
+    // unicorn v65 からファイル名に加えてディレクトリ名もチェック対象となったが、
+    // ignore オプションはマッチしたセグメントを含むファイル全体をスキップするため
+    // ファイル名チェック自体まで無効化してしまう。
+    // そのため checkDirectories: false でディレクトリ名チェックのみ無効化する。
+    // src 等の慣習的なディレクトリ名でエラーが起きる問題もこれで解消される。
+    // __tests__ や __mocks__ 等のダブルアンダースコアディレクトリは引き続き
+    // ignore で対象外とする（テストファイル等はファイル名チェックも不要なため）。
     rules: {
-      "unicorn/filename-case": ["error", { ignore: [/^__[\w-]+__$/] }],
+      "unicorn/filename-case": [
+        "error",
+        { checkDirectories: false, ignore: [/^__[\w-]+__$/] },
+      ],
     },
   },
   {

--- a/test.mjs
+++ b/test.mjs
@@ -194,9 +194,16 @@ async function main() {
       dir: "__mocks__",
     },
     {
-      name: "filename-case: kebab-case でないディレクトリ名はエラー",
+      name: "filename-case: src ディレクトリはケースチェック対象外（OK）",
       code: "export const a = 1;",
-      shouldError: true,
+      shouldError: false,
+      rules: ["unicorn/filename-case"],
+      dir: "src",
+    },
+    {
+      name: "filename-case: checkDirectories: false のため kebab-case でないディレクトリ名もエラーにならない（OK）",
+      code: "export const a = 1;",
+      shouldError: false,
       rules: ["unicorn/filename-case"],
       dir: "notKebabCaseDir",
     },


### PR DESCRIPTION
## 概要

unicorn v65 でファイル名に加えてディレクトリ名もチェック対象となりましたが、
`ignore` オプションの動作上の問題と `src` 等の慣習的なディレクトリ名との
コンフリクトが発生していたため、`checkDirectories: false` で対応します。

## 問題

### `ignore` オプションの副作用

`unicorn/filename-case` の `ignore` オプションは「マッチしたセグメントを含む
ファイル全体をスキップ」という動作です（ソースの該当箇所）：

```js
// eslint-plugin-unicorn/rules/filename-case.js
if (pathSegments.some(segment => ignore.some(regexp => regexp.test(segment)))) {
  return; // ファイル全体をスキップ（ファイル名チェックまで無効化される）
}
```

そのため `ignore: [/^src$/]` を追加すると `src/` 配下の**ファイル名チェックも
含めて完全に無効化**されてしまいます（`src/NotKebabCase.ts` も通過してしまう）。

### `src` ディレクトリのエラー

unicorn v65 のディレクトリ名チェックにより、`src/App.vue` のような一般的な
パスで「Directory name `src` is not in pascal case」等のエラーが発生します。
`src` はプロジェクトの慣習的なディレクトリ名であり、リネームは現実的でありません。

## 修正内容

### `index.mjs`

`checkDirectories: false` を追加し、ディレクトリ名チェックのみを無効化します。

```js
// 変更前
"unicorn/filename-case": ["error", { ignore: [/^__[\w-]+__$/] }]

// 変更後
"unicorn/filename-case": ["error", { checkDirectories: false, ignore: [/^__[\w-]+__$/] }]
```

- ファイル名チェックは引き続き機能する（`kebab-case` 等の規則は有効）
- ディレクトリ名チェックは無効化（`src`、`components` 等の慣習的なディレクトリ名を許容）
- `__tests__` / `__mocks__` 等は引き続き `ignore` でファイル全体をスキップ

### `test.mjs`

- `src` ディレクトリでエラーが発生しないことを確認するテストを追加
- `notKebabCaseDir` テストをディレクトリ名チェック無効の動作に合わせて更新（エラーなし）

## テスト結果

`node test.mjs` で 33/33 テスト通過を確認済みです。
