### PR TITLE
feat: .vue ファイルに unicorn/filename-case の pascalCase を適用するルールブロックを追加

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -99,6 +99,22 @@ export default tseslint.config(
     },
   },
   {
+    // Vue コンポーネントは PascalCase の命名規則が慣習であるため、
+    // .vue ファイルに限り pascalCase を適用する。
+    // unicorn/filename-case のルールは ESLint flat config の「最後に定義したルールが勝つ」
+    // 仕様により、プロジェクト側でオーバーライドするとここで設定した checkDirectories: false
+    // も上書きされてしまう。
+    // そのため、プロジェクト側で filename-case を再定義せずにこのデフォルト設定を
+    // 使い続けられるよう、あらかじめ checkDirectories: false も含めて設定する。
+    files: ["**/*.vue"],
+    rules: {
+      "unicorn/filename-case": [
+        "error",
+        { case: "pascalCase", checkDirectories: false },
+      ],
+    },
+  },
+  {
     ignores: ["dist", "output", "node_modules", "data", "logs", "coverage"],
   },
   eslintPrettier


### PR DESCRIPTION
## 概要

`unicorn/filename-case` の `**/*.vue` 向けルールブロックを追加し、Vue コンポーネントファイルに対して `pascalCase` を適用するようにします。

## 背景

Vue コンポーネントのファイル名は `PascalCase` が慣習であり、多くのVueプロジェクト（Vue公式ガイドを含む）がこの命名規則を採用しています。

現在の `@book000/eslint-config` はデフォルトで `kebab-case` を適用するため、Vue プロジェクトでは必ずプロジェクト側で `filename-case` をオーバーライドする必要があります。

## 変更内容

`index.mjs` に `**/*.vue` 向けのルールブロックを追加しました。

```js
{
  files: ["**/*.vue"],
  rules: {
    "unicorn/filename-case": [
      "error",
      { case: "pascalCase", checkDirectories: false },
    ],
  },
},
```

`checkDirectories: false` も合わせて設定することで、#536 で対応したディレクトリ名チェック無効化が `.vue` ファイルにも引き継がれます。

## 効果

このブロックがリリースされると、Vue プロジェクト側では `filename-case` のオーバーライド定義が不要になります。

> **ESLint flat config の仕様について**
>
> flat config では「最後に定義したルールが完全に上書きする」仕様のため、プロジェクト側に `**/*.vue` ブロックが存在してもそのブロックが `filename-case` を再定義しない限り、この共有 config のルールが有効になります。

## テスト

既存の 33 件のテストがすべて pass しています。