### PR TITLE
fix: devcontainer の image タグを更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
   "name": "ESLint Config DevContainer",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:24-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:24",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
-    },
     "ghcr.io/devcontainers/features/git:1": {}
   },
   "customizations": {


### PR DESCRIPTION
## 変更内容

devcontainer の image タグを Renovate が自動更新できる形式に変更します。

### 変更

- `image`: `mcr.microsoft.com/devcontainers/typescript-node:24-bullseye` → `mcr.microsoft.com/devcontainers/typescript-node:24`
- features の冗長な `node:1` エントリを削除（typescript-node イメージに統合済みのため）

### 理由

`X-Y` 形式のタグ（例: `1-18`）や `X-OS` 形式（例: `24-bullseye`）は Renovate の devcontainer マネージャーが検出できないため、バージョン番号のみの形式（`24`）に統一します。

これにより将来の Node.js LTS 更新が Renovate で自動管理されます。

ref: book000/book000#118