### PR TITLE
fix repository metadata URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.mjs",
   "repository": {
     "type": "git",
-    "url": "git@github.com:book000/eslint-config.git"
+    "url": "git+https://github.com/book000/eslint-config.git"
   },
   "dependencies": {
     "@typescript-eslint/parser": "8.61.0",


### PR DESCRIPTION
## Summary

- update the package repository URL from SSH shorthand to the npm-friendly `git+https` form
- keep the existing homepage and bugs metadata unchanged

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/book000/eslint-config.git') process.exit(1); console.log(p.repository.url)"`
- `git diff --check`
- `npm --cache /private/tmp/codex-npm-cache pack --dry-run --ignore-scripts --json`

Note: the pack dry-run reports the existing `.gitignore` fallback warning because the repo does not include a `.npmignore`; no packaging error was reported with a temporary npm cache.
