### PR TITLE
fix: unicorn/consistent-class-member-order を無効化

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -68,6 +68,9 @@ export default tseslint.config(
       "@typescript-eslint/no-use-before-define": "error",
       // トップレベルのawaitを許可する
       "unicorn/prefer-top-level-await": "off",
+      // クラスメンバーの順序（private before public）を強制しない。
+      // public-first の慣習はAPIの可読性として広く使われているため。
+      "unicorn/consistent-class-member-order": "off",
       // 省略形を許可する (dev -> development, prod -> productionなどの変換をさせない)
       "unicorn/prevent-abbreviations": "off",
       // nullを許可する

--- a/index.mjs
+++ b/index.mjs
@@ -69,7 +69,7 @@ export default tseslint.config(
       // トップレベルのawaitを許可する
       "unicorn/prefer-top-level-await": "off",
       // クラスメンバーの順序（private before public）を強制しない。
-      // public-first の慣習はAPIの可読性として広く使われているため。
+      // public-first の慣習は API の可読性として広く使われているため。
       "unicorn/consistent-class-member-order": "off",
       // 省略形を許可する (dev -> development, prod -> productionなどの変換をさせない)
       "unicorn/prevent-abbreviations": "off",

--- a/test.mjs
+++ b/test.mjs
@@ -201,6 +201,12 @@ async function main() {
       dir: "src",
     },
     {
+      name: "consistent-class-member-order: public フィールドの後に private フィールドが来てもエラーにならない（OK）",
+      code: "class Foo { public name: string = 'foo'; private id: number = 1; }",
+      shouldError: false,
+      rules: ["unicorn/consistent-class-member-order"],
+    },
+    {
       name: "filename-case: checkDirectories: false のため kebab-case でないディレクトリ名もエラーにならない（OK）",
       code: "export const a = 1;",
       shouldError: false,


### PR DESCRIPTION
## 概要

unicorn v66 で追加された `unicorn/consistent-class-member-order` ルールを無効化します。

## 背景

`eslint-plugin-unicorn` v66 では新規ルールが大量追加され、`consistent-class-member-order` が `recommended: true` として有効化されました。このルールは private メンバーを public メンバーより前に配置することを強制しますが、以下の理由から無効化が適切と判断しました。

- **public-first の慣習と相反する** — クラスの公開 API を先頭に示す public-first は可読性の観点で広く用いられています
- **コミュニティでの棄却率が高い** — 30 リポジトリ横断調査でも同ルールを無効化するプロジェクトが多数確認されました
- **バグ検知への寄与なし** — 純粋なスタイル強制であり、コードの正確性には無関係です

## 変更内容

`index.mjs` に以下を追加：

```js
// クラスメンバーの順序（private before public）を強制しない。
// public-first の慣習はAPIの可読性として広く使われているため。
"unicorn/consistent-class-member-order": "off",
```

## 影響範囲

このパッケージを使用している各リポジトリの `@book000/eslint-config` v1.15.5 更新 Renovate PR が CI を通過するようになります。