### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "index.mjs",
   "repository": {
     "type": "git",
-    "url": "git@github.com:book000/eslint-config.git"
+    "url": "git+https://github.com/book000/eslint-config.git"
   },
   "dependencies": {
     "@typescript-eslint/parser": "8.61.1",


### PR DESCRIPTION
## Summary
- update the package repository URL from the SSH/SCP GitHub form to the public `git+https` form
- leave package name, homepage, bugs URL, license, runtime code, dependencies, and package contents unchanged

## Validation
- `npm view @book000/eslint-config@1.15.8 name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if (p.name !== '@book000/eslint-config') throw new Error('wrong package'); if (p.repository.url !== 'git+https://github.com/book000/eslint-config.git') throw new Error('repository metadata missing'); if (p.homepage !== 'https://github.com/book000/eslint-config') throw new Error('homepage changed'); if (p.bugs.url !== 'https://github.com/book000/eslint-config/issues') throw new Error('bugs changed'); if (p.license !== 'MIT') throw new Error('license changed'); console.log('metadata ok')"`
- `pnpm --pm-on-fail=ignore install --frozen-lockfile --ignore-scripts`
- `pnpm test`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`