### PR TITLE
fix: 誤検知率の高い unicorn ルール 12 件の無効化と test.mjs の OOM 修正

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -48,12 +48,55 @@ export default tseslint.config(
       // クラスメンバーの順序（private before public）を強制しない。
       // public-first の慣習は API の可読性として広く使われているため。
       "unicorn/consistent-class-member-order": "off",
+      // 依存プロジェクト横断での実運用調査 (tomacheese/book000/jaoafa 各オーガニゼーション規模) の
+      // 結果、誤検知率が高く実利が薄いと判断したルールを以下のとおり無効化する。
+      //
+      // .then()/.catch()/.finally() チェーンを await へ書き換えるよう強制するが、
+      // 関数自体を async 化したくない薄いラッパー関数 (Promise を返すだけの関数) まで
+      // 書き換え対象になり実利が薄いため無効化する
+      "unicorn/prefer-await": "off",
+      // is/has/should 等のプレフィックスを強制するが、ドメイン語彙由来の真偽値変数名
+      // (enabled, visible 等) まで誤検知するため無効化する
+      "unicorn/consistent-boolean-name": "off",
+      // get/set/create 等の動詞プレフィックスを持つ関数以外の値 (変数・プロパティ等) を
+      // 検出するが、removeButton (削除用ボタン要素を指す変数名) のようなドメイン語彙由来の
+      // 命名まで誤検知するため無効化する
+      "unicorn/no-non-function-verb-prefix": "off",
+      // Number() による型強制を強制するが、parseInt 等との挙動差 (NaN の扱い等) により
+      // 意図せず動作が変わる危険があるため無効化する
+      "unicorn/prefer-number-coercion": "off",
+      // モジュールトップレベル変数へのキャッシュ/メモ化目的の代入という一般的な
+      // パターンまで誤検知するため無効化する
+      "unicorn/no-top-level-assignment-in-function": "off",
+      // \uXXXX と \u{XXXX} は等価であり、既存コードへの機械的な書き換えを強制する
+      // だけで実利が薄いため無効化する
+      "unicorn/prefer-unicode-code-point-escapes": "off",
+      // ネストしたループ内の break による意図的な早期脱出パターンまで誤検知するため
+      // 無効化する
+      "unicorn/no-break-in-nested-loop": "off",
+      // 継承・拡張を意図した static メソッド内でのクラス名参照という正当な
+      // パターンまで誤検知するため無効化する
+      "unicorn/class-reference-in-static-methods": "off",
+      // while (true) の先頭で break 条件を判定するコードを、条件を while() の式へ
+      // 移すよう強制するが、ループ内で算出した値を break 条件に使うイディオム
+      // (while (true) { const chunk = readNext(); if (!chunk) break; ... }) まで
+      // 誤検知するため無効化する
+      "unicorn/prefer-while-loop-condition": "off",
+      // location.href への代入と location.assign() はほぼ等価であり、機械的な
+      // 書き換えを強制するだけで実利が薄いため無効化する
+      "unicorn/prefer-location-assign": "off",
+      // 呼び出しの引数として渡された呼び出しの入れ子の深さを検出するが、
+      // z.array(z.object({ ... })) のような Zod 等のスキーマ定義における正当な
+      // 入れ子呼び出しまで誤検知するため無効化する
+      "unicorn/max-nested-calls": "off",
+      // globalThis/window/global のプロパティへの代入は、テストやモックの
+      // セットアップにおける標準的なイディオム (globalThis.fetch = mock 等) であり、
+      // 実運用コードでの誤検知率が高いため無効化する
+      "unicorn/no-global-object-property-assignment": "off",
       //
       // 以下、上記以外の flat/recommended 収録ルールをすべて明示的に error とする
       "unicorn/better-dom-traversing": "error",
-      "unicorn/class-reference-in-static-methods": "error",
       "unicorn/consistent-assert": "error",
-      "unicorn/consistent-boolean-name": "error",
       "unicorn/consistent-compound-words": "error",
       "unicorn/consistent-conditional-object-spread": "error",
       "unicorn/consistent-date-clone": "error",
@@ -75,7 +118,6 @@ export default tseslint.config(
       "unicorn/import-style": "error",
       "unicorn/isolated-functions": "error",
       "unicorn/logical-assignment-operators": "error",
-      "unicorn/max-nested-calls": "error",
       "unicorn/new-for-builtins": "error",
       "unicorn/no-abusive-eslint-disable": "error",
       "unicorn/no-accessor-recursion": "error",
@@ -95,7 +137,6 @@ export default tseslint.config(
       "unicorn/no-await-in-promise-methods": "error",
       "unicorn/no-blob-to-file": "error",
       "unicorn/no-boolean-sort-comparator": "error",
-      "unicorn/no-break-in-nested-loop": "error",
       "unicorn/no-canvas-to-image": "error",
       "unicorn/no-chained-comparison": "error",
       "unicorn/no-collection-bracket-access": "error",
@@ -116,7 +157,6 @@ export default tseslint.config(
       "unicorn/no-exports-in-scripts": "error",
       "unicorn/no-for-each": "error",
       "unicorn/no-for-loop": "error",
-      "unicorn/no-global-object-property-assignment": "error",
       "unicorn/no-immediate-mutation": "error",
       "unicorn/no-impossible-length-comparison": "error",
       "unicorn/no-incorrect-query-selector": "error",
@@ -142,7 +182,6 @@ export default tseslint.config(
       "unicorn/no-nested-ternary": "error",
       "unicorn/no-new-array": "error",
       "unicorn/no-new-buffer": "error",
-      "unicorn/no-non-function-verb-prefix": "error",
       "unicorn/no-nonstandard-builtin-properties": "error",
       "unicorn/no-object-as-default-parameter": "error",
       "unicorn/no-object-methods-with-collections": "error",
@@ -157,7 +196,6 @@ export default tseslint.config(
       "unicorn/no-thenable": "error",
       "unicorn/no-this-assignment": "error",
       "unicorn/no-this-outside-of-class": "error",
-      "unicorn/no-top-level-assignment-in-function": "error",
       "unicorn/no-top-level-side-effects": "error",
       "unicorn/no-typeof-undefined": "error",
       "unicorn/no-uncalled-method": "error",
@@ -223,7 +261,6 @@ export default tseslint.config(
       "unicorn/prefer-array-slice": "error",
       "unicorn/prefer-array-some": "error",
       "unicorn/prefer-at": "error",
-      "unicorn/prefer-await": "error",
       "unicorn/prefer-bigint-literals": "error",
       "unicorn/prefer-blob-reading-methods": "error",
       "unicorn/prefer-block-statement-over-iife": "error",
@@ -259,7 +296,6 @@ export default tseslint.config(
       "unicorn/prefer-iterator-to-array": "error",
       "unicorn/prefer-iterator-to-array-at-end": "error",
       "unicorn/prefer-keyboard-event-key": "error",
-      "unicorn/prefer-location-assign": "error",
       "unicorn/prefer-logical-operator-over-ternary": "error",
       "unicorn/prefer-map-from-entries": "error",
       "unicorn/prefer-math-abs": "error",
@@ -273,7 +309,6 @@ export default tseslint.config(
       "unicorn/prefer-native-coercion-functions": "error",
       "unicorn/prefer-negative-index": "error",
       "unicorn/prefer-node-protocol": "error",
-      "unicorn/prefer-number-coercion": "error",
       "unicorn/prefer-number-is-safe-integer": "error",
       "unicorn/prefer-number-properties": "error",
       "unicorn/prefer-object-define-properties": "error",
@@ -321,11 +356,9 @@ export default tseslint.config(
       "unicorn/prefer-type-error": "error",
       "unicorn/prefer-type-literal-last": "error",
       "unicorn/prefer-unary-minus": "error",
-      "unicorn/prefer-unicode-code-point-escapes": "error",
       "unicorn/prefer-url-can-parse": "error",
       "unicorn/prefer-url-href": "error",
       "unicorn/prefer-url-search-parameters": "error",
-      "unicorn/prefer-while-loop-condition": "error",
       "unicorn/relative-url-style": "error",
       "unicorn/require-array-join-separator": "error",
       "unicorn/require-array-sort-compare": "error",

--- a/test.mjs
+++ b/test.mjs
@@ -1,7 +1,10 @@
 // Node.jsスクリプトでESLint flat config(index.mjs)の動作を検証するサンプル
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import fs from "fs";
 import path from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 async function main() {
   const testCases = [
@@ -219,6 +222,78 @@ async function main() {
       rules: ["unicorn/consistent-class-member-order"],
     },
     {
+      name: "prefer-await: .then() チェーンを使う非asyncな薄いラッパー関数はOK",
+      code: "function getValue(): Promise<number> { return Promise.resolve(1).then((value) => value); }",
+      shouldError: false,
+      rules: ["unicorn/prefer-await"],
+    },
+    {
+      name: "consistent-boolean-name: is/has等のプレフィックスがない真偽値変数名はOK",
+      code: "const enabled: boolean = true;",
+      shouldError: false,
+      rules: ["unicorn/consistent-boolean-name"],
+    },
+    {
+      name: "no-non-function-verb-prefix: 動詞プレフィックスを持つ非関数の変数名はOK",
+      code: "const removeButton = 1;",
+      shouldError: false,
+      rules: ["unicorn/no-non-function-verb-prefix"],
+    },
+    {
+      name: "prefer-number-coercion: parseInt による数値変換はOK",
+      code: "const n = parseInt('1', 10);",
+      shouldError: false,
+      rules: ["unicorn/prefer-number-coercion"],
+    },
+    {
+      name: "no-top-level-assignment-in-function: トップレベル変数へのキャッシュ代入はOK",
+      code: "let cache: number | undefined; function setCache(): void { cache = 1; }",
+      shouldError: false,
+      rules: ["unicorn/no-top-level-assignment-in-function"],
+    },
+    {
+      name: "prefer-unicode-code-point-escapes: \\uXXXX形式のエスケープはOK",
+      code: "const s = '\\u00e9';",
+      shouldError: false,
+      rules: ["unicorn/prefer-unicode-code-point-escapes"],
+    },
+    {
+      name: "no-break-in-nested-loop: ネストしたループ内のbreakによる早期脱出はOK",
+      code: "for (let i = 0; i < 3; i++) { for (let j = 0; j < 3; j++) { if (j === 1) break; } }",
+      shouldError: false,
+      rules: ["unicorn/no-break-in-nested-loop"],
+    },
+    {
+      name: "class-reference-in-static-methods: staticメソッド内での非呼び出し位置のクラス名参照はOK",
+      code: "class Foo { static bar = 1; static create(): number { return Foo.bar; } }",
+      shouldError: false,
+      rules: ["unicorn/class-reference-in-static-methods"],
+    },
+    {
+      name: "prefer-while-loop-condition: while(true) + 内部breakによる終了判定はOK",
+      code: "let i = 0; while (true) { if (i >= 5) break; i++; }",
+      shouldError: false,
+      rules: ["unicorn/prefer-while-loop-condition"],
+    },
+    {
+      name: "prefer-location-assign: location.hrefへの代入はOK",
+      code: "location.href = 'https://example.com';",
+      shouldError: false,
+      rules: ["unicorn/prefer-location-assign"],
+    },
+    {
+      name: "max-nested-calls: スキーマ定義等のメソッドチェーンによる深いネストはOK",
+      code: "function a(x: number) { return b(x); } function b(x: number) { return c(x); } function c(x: number) { return d(x); } function d(x: number) { return x; } const result = a(b(c(d(1))));",
+      shouldError: false,
+      rules: ["unicorn/max-nested-calls"],
+    },
+    {
+      name: "no-global-object-property-assignment: globalThisプロパティへの代入（テストのモック等）はOK",
+      code: "globalThis.fetch = (() => Promise.resolve(new Response())) as typeof fetch;",
+      shouldError: false,
+      rules: ["unicorn/no-global-object-property-assignment"],
+    },
+    {
       name: "filename-case: checkDirectories: false のため kebab-case でないディレクトリ名もエラーにならない（OK）",
       code: "export const a = 1;",
       shouldError: false,
@@ -276,57 +351,98 @@ async function main() {
   const flatConfigPath = path.join(process.cwd(), "eslint.config.mjs");
   fs.copyFileSync(path.join(process.cwd(), "index.mjs"), flatConfigPath);
 
-  // 並列実行用のPromise配列
-  const promises = testCases.map((testCase, i) => {
-    return new Promise((resolve) => {
-      const { name, code, shouldError, rules, dir } = testCase;
-      const kebabName = `test-${i}.ts`;
-      const targetDir = dir ? path.join(srcDir, dir) : tmpDir;
-      const tmpFilePath = path.join(targetDir, kebabName);
-      fs.writeFileSync(tmpFilePath, code);
-      exec(
-        `npx eslint --no-cache --ext .ts ${tmpFilePath}`,
-        (error, stdout, stderr) => {
-          const output = (stdout || "") + (stderr || "");
-          // テスト項目ごとに対象ルールのみを判定
-          const errorLines = output
-            .split("\n")
-            .filter((line) => line.match(/error/));
-          let errorCount = 0;
-          let ignoredErrors = [];
-          const relevantErrors = [];
-          for (const line of errorLines) {
-            const ruleMatch = line.match(/\s([\w@\-/]+)$/);
-            const rule = ruleMatch ? ruleMatch[1] : null;
-            if (rule && rules.includes(rule)) {
-              errorCount = 1;
-              relevantErrors.push(line);
-            } else {
-              ignoredErrors.push(line);
-            }
-          }
-          fs.unlinkSync(tmpFilePath);
-          resolve({
-            name,
-            shouldError,
-            errorCount,
-            output,
-            relevantErrors,
-            ignoredErrors,
-          });
-        }
-      );
-    });
+  // テスト用一時ファイルをすべて書き出す (プロセス起動は後で 1 回だけ行う)
+  const tmpFilePaths = testCases.map((testCase, i) => {
+    const { code, dir } = testCase;
+    const kebabName = `test-${i}.ts`;
+    const targetDir = dir ? path.join(srcDir, dir) : tmpDir;
+    const tmpFilePath = path.join(targetDir, kebabName);
+    fs.writeFileSync(tmpFilePath, code);
+    return tmpFilePath;
   });
 
-  const results = await Promise.all(promises);
+  // 全テストケースを 1 回の eslint 起動でまとめて検証する。
+  // 以前はテストケースごとに `npx eslint` を並列起動していたため、
+  // type-aware (typescript-eslint) なパーサ初期化がテストケース数分同時に走り、
+  // メモリ枯渇・OOM killer の引き金になっていた。
+  // 1 プロセス・1 回の TypeScript プログラム初期化にまとめることで、
+  // プロセス数をテストケース数から 1 に減らし、メモリ使用量を大幅に下げる。
+  const eslintBinPath = path.join(
+    process.cwd(),
+    "node_modules",
+    "eslint",
+    "bin",
+    "eslint.js"
+  );
+  let jsonOutput = "";
+  try {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        eslintBinPath,
+        "--no-cache",
+        "--ext",
+        ".ts",
+        "--format",
+        "json",
+        ...tmpFilePaths,
+      ],
+      { maxBuffer: 1024 * 1024 * 50 }
+    );
+    jsonOutput = stdout;
+  } catch (error) {
+    // eslint はテストケースに期待どおりのエラーがあると非ゼロの exit code を返すが、
+    // これはテストとして期待される挙動なので、JSON 形式の stdout が取れていれば
+    // 正常系として扱う。設定エラー等で stdout に JSON が出力されない場合は
+    // ここでは判別せず、後続の JSON.parse で例外として検出させる。
+    if (error.stdout) {
+      jsonOutput = error.stdout;
+    } else {
+      throw error;
+    }
+  }
+
+  const eslintResults = JSON.parse(jsonOutput);
+  const resultsByFilePath = new Map(
+    eslintResults.map((result) => [result.filePath, result])
+  );
+
+  const results = testCases.map((testCase, i) => {
+    const { name, shouldError, rules } = testCase;
+    const tmpFilePath = tmpFilePaths[i];
+    const fileResult = resultsByFilePath.get(tmpFilePath);
+    if (!fileResult) {
+      // 対象ファイルが eslint の結果に存在しない場合、空メッセージとして
+      // 握りつぶすと「エラー 0 件 = OK」と誤ってパスしてしまう。
+      // ファイルが実際には lint されていないことを示すため、例外として検出する。
+      throw new Error(
+        `ESLint did not return a result for temp file: ${tmpFilePath}`
+      );
+    }
+
+    let errorCount = 0;
+    const relevantErrors = [];
+    const ignoredErrors = [];
+    for (const message of fileResult.messages) {
+      const severityLabel = message.severity === 2 ? "error" : "warning";
+      const line = `  ${message.line}:${message.column}  ${severityLabel}  ${message.message}  ${message.ruleId ?? ""}`;
+      if (message.ruleId && rules.includes(message.ruleId)) {
+        errorCount = 1;
+        relevantErrors.push(line);
+      } else {
+        ignoredErrors.push(line);
+      }
+    }
+
+    fs.unlinkSync(tmpFilePath);
+    return { name, shouldError, errorCount, relevantErrors, ignoredErrors };
+  });
   let pass = 0,
     fail = 0;
   for (const {
     name,
     shouldError,
     errorCount,
-    output,
     relevantErrors,
     ignoredErrors,
   } of results) {


### PR DESCRIPTION
## 概要

以下 2 点をまとめて対応する。

1. `index.mjs`: 誤検知率が高く実利が薄いと判断した unicorn ルール 12 件を無効化する。
   tomacheese/book000/jaoafa 各オーガニゼーションの既存プロジェクトを横断的に調査した結果に基づく判断。
2. `test.mjs`: テスト検証スクリプトが OOM killer に殺される問題を解消する。

## 詳細

### unicorn ルール 12 件の無効化 (index.mjs)

無効化したルールと理由は `index.mjs` 内のコメントに記載。各ルールに対応するテストケースを `test.mjs` に追加済み。

### test.mjs の OOM 修正

これまで test.mjs は 1 テストケースにつき `npx eslint` を並列起動していた。テストケース数分の
type-aware (typescript-eslint) な TypeScript プログラム初期化が同時に走ることでメモリを大量消費し、
ホストの OOM killer が発火する事象を確認した(cgroup の `memory.events` の `oom_kill` カウンタ増分により
ライブ再現で確認済み)。

全テストケースを 1 回の `eslint --format json` 起動にまとめ、結果を `filePath`/`ruleId` で突き合わせる方式に
変更し、プロセス数をテストケース数から 1 に削減した。あわせて、対象ファイルが eslint の結果に存在しない場合に
無条件で成功扱いにしてしまうフォールバックを、例外として検出するように修正した。

## 動作確認

- `node test.mjs` で 48/48 成功を確認。
- 修正前後で `oom_kill` カウンタが増加しないことを確認。
- 無効化した 12 ルールに対応する新規テストケースは、対象ルールを一時的に有効化した状態で実際に発火することを確認済み。
